### PR TITLE
#114 Dキー押したときに次のタスクがトップ丁度ではなく少し下に表示される様にして前の直前のタスクが見える様にした

### DIFF
--- a/src/views/TaskListMain.vue
+++ b/src/views/TaskListMain.vue
@@ -351,7 +351,7 @@ export default class TaskListMain extends Vue {
 
   private jumpToNextTask(): void {
     this.$nextTick(() => {
-      this.$vuetify.goTo('#next-task', {duration: 350, easing: 'easeInOutCubic'})
+      this.$vuetify.goTo('#next-task', {duration: 350, easing: 'easeInOutCubic', offset: 200})
     })
   }
   private jumpToTop(): void {


### PR DESCRIPTION
#114 の対応