### PR TITLE
DateUtilのユニットテスト対応

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1518,7 +1518,7 @@
         },
         "whatwg-fetch": {
           "version": "2.0.4",
-          "resolved": "https://registry.npmjs.org/whatwg-fetch/-/whatwg-fetch-2.0.4.tgz",
+          "resolved": "http://registry.npmjs.org/whatwg-fetch/-/whatwg-fetch-2.0.4.tgz",
           "integrity": "sha512-dcQ1GWpOD/eEQ97k66aiEVpNnapVj90/+R+SXTPYGHpYBBypfKJEQjLrvMZ7YXbKm21gXd4NcuxUTjiv1YtLng=="
         }
       }
@@ -3158,6 +3158,50 @@
             "jest-validate": "^23.6.0",
             "micromatch": "^2.3.11",
             "pretty-format": "^23.6.0"
+          },
+          "dependencies": {
+            "babel-core": {
+              "version": "6.26.3",
+              "resolved": "https://registry.npmjs.org/babel-core/-/babel-core-6.26.3.tgz",
+              "integrity": "sha512-6jyFLuDmeidKmUEb3NM+/yawG0M2bDZ9Z1qbZP59cyHLz8kYGKYwpJP0UwUKKUiTRNvxfLesJnTedqczP7cTDA==",
+              "dev": true,
+              "requires": {
+                "babel-code-frame": "^6.26.0",
+                "babel-generator": "^6.26.0",
+                "babel-helpers": "^6.24.1",
+                "babel-messages": "^6.23.0",
+                "babel-register": "^6.26.0",
+                "babel-runtime": "^6.26.0",
+                "babel-template": "^6.26.0",
+                "babel-traverse": "^6.26.0",
+                "babel-types": "^6.26.0",
+                "babylon": "^6.18.0",
+                "convert-source-map": "^1.5.1",
+                "debug": "^2.6.9",
+                "json5": "^0.5.1",
+                "lodash": "^4.17.4",
+                "minimatch": "^3.0.4",
+                "path-is-absolute": "^1.0.1",
+                "private": "^0.1.8",
+                "slash": "^1.0.0",
+                "source-map": "^0.5.7"
+              }
+            },
+            "debug": {
+              "version": "2.6.9",
+              "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+              "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+              "dev": true,
+              "requires": {
+                "ms": "2.0.0"
+              }
+            },
+            "ms": {
+              "version": "2.0.0",
+              "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+              "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+              "dev": true
+            }
           }
         },
         "jest-diff": {
@@ -3368,6 +3412,50 @@
             "strip-bom": "3.0.0",
             "write-file-atomic": "^2.1.0",
             "yargs": "^11.0.0"
+          },
+          "dependencies": {
+            "babel-core": {
+              "version": "6.26.3",
+              "resolved": "https://registry.npmjs.org/babel-core/-/babel-core-6.26.3.tgz",
+              "integrity": "sha512-6jyFLuDmeidKmUEb3NM+/yawG0M2bDZ9Z1qbZP59cyHLz8kYGKYwpJP0UwUKKUiTRNvxfLesJnTedqczP7cTDA==",
+              "dev": true,
+              "requires": {
+                "babel-code-frame": "^6.26.0",
+                "babel-generator": "^6.26.0",
+                "babel-helpers": "^6.24.1",
+                "babel-messages": "^6.23.0",
+                "babel-register": "^6.26.0",
+                "babel-runtime": "^6.26.0",
+                "babel-template": "^6.26.0",
+                "babel-traverse": "^6.26.0",
+                "babel-types": "^6.26.0",
+                "babylon": "^6.18.0",
+                "convert-source-map": "^1.5.1",
+                "debug": "^2.6.9",
+                "json5": "^0.5.1",
+                "lodash": "^4.17.4",
+                "minimatch": "^3.0.4",
+                "path-is-absolute": "^1.0.1",
+                "private": "^0.1.8",
+                "slash": "^1.0.0",
+                "source-map": "^0.5.7"
+              }
+            },
+            "debug": {
+              "version": "2.6.9",
+              "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+              "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+              "dev": true,
+              "requires": {
+                "ms": "2.0.0"
+              }
+            },
+            "ms": {
+              "version": "2.0.0",
+              "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+              "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+              "dev": true
+            }
           }
         },
         "jest-serializer": {
@@ -3438,6 +3526,12 @@
           "requires": {
             "merge-stream": "^1.0.1"
           }
+        },
+        "json5": {
+          "version": "0.5.1",
+          "resolved": "https://registry.npmjs.org/json5/-/json5-0.5.1.tgz",
+          "integrity": "sha1-Hq3nrMASA0rYTiOWdn6tn6VJWCE=",
+          "dev": true
         },
         "kind-of": {
           "version": "3.2.2",
@@ -4803,60 +4897,10 @@
       }
     },
     "babel-core": {
-      "version": "6.26.3",
-      "resolved": "https://registry.npmjs.org/babel-core/-/babel-core-6.26.3.tgz",
-      "integrity": "sha512-6jyFLuDmeidKmUEb3NM+/yawG0M2bDZ9Z1qbZP59cyHLz8kYGKYwpJP0UwUKKUiTRNvxfLesJnTedqczP7cTDA==",
-      "dev": true,
-      "requires": {
-        "babel-code-frame": "^6.26.0",
-        "babel-generator": "^6.26.0",
-        "babel-helpers": "^6.24.1",
-        "babel-messages": "^6.23.0",
-        "babel-register": "^6.26.0",
-        "babel-runtime": "^6.26.0",
-        "babel-template": "^6.26.0",
-        "babel-traverse": "^6.26.0",
-        "babel-types": "^6.26.0",
-        "babylon": "^6.18.0",
-        "convert-source-map": "^1.5.1",
-        "debug": "^2.6.9",
-        "json5": "^0.5.1",
-        "lodash": "^4.17.4",
-        "minimatch": "^3.0.4",
-        "path-is-absolute": "^1.0.1",
-        "private": "^0.1.8",
-        "slash": "^1.0.0",
-        "source-map": "^0.5.7"
-      },
-      "dependencies": {
-        "debug": {
-          "version": "2.6.9",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
-          "dev": true,
-          "requires": {
-            "ms": "2.0.0"
-          }
-        },
-        "json5": {
-          "version": "0.5.1",
-          "resolved": "https://registry.npmjs.org/json5/-/json5-0.5.1.tgz",
-          "integrity": "sha1-Hq3nrMASA0rYTiOWdn6tn6VJWCE=",
-          "dev": true
-        },
-        "ms": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
-          "dev": true
-        },
-        "slash": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/slash/-/slash-1.0.0.tgz",
-          "integrity": "sha1-xB8vbDn8FtHNF61LXYlhFK5HDVU=",
-          "dev": true
-        }
-      }
+      "version": "7.0.0-bridge.0",
+      "resolved": "https://registry.npmjs.org/babel-core/-/babel-core-7.0.0-bridge.0.tgz",
+      "integrity": "sha512-poPX9mZH/5CSanm50Q+1toVci6pv5KSRv/5TWCwtzQS5XEwn40BcCrgIeMFWP9CKKIniKXNxoIOnOq4VVlGXhg==",
+      "dev": true
     },
     "babel-extract-comments": {
       "version": "1.0.0",
@@ -5269,7 +5313,7 @@
         },
         "json5": {
           "version": "0.5.1",
-          "resolved": "http://registry.npmjs.org/json5/-/json5-0.5.1.tgz",
+          "resolved": "https://registry.npmjs.org/json5/-/json5-0.5.1.tgz",
           "integrity": "sha1-Hq3nrMASA0rYTiOWdn6tn6VJWCE=",
           "dev": true
         },

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "@vue/cli-plugin-unit-jest": "^3.8.0",
     "@vue/cli-service": "^3.8.4",
     "@vue/test-utils": "^1.0.0-beta.29",
-    "babel-core": "^6.26.3",
+    "babel-core": "^7.0.0-bridge.0",
     "babel-jest": "^24.8.0",
     "jest": "^24.8.0",
     "sass-loader": "^7.0.1",

--- a/src/store/StoreUtil.ts
+++ b/src/store/StoreUtil.ts
@@ -1,0 +1,8 @@
+import Store from '@/store/Store'
+import Section from '@/lib/Section';
+
+export default class StoreUtil {
+  public static getSectionList(): Section[] {
+    return Store.getters['section/sections']
+  }
+}

--- a/src/util/DateUtil.ts
+++ b/src/util/DateUtil.ts
@@ -1,5 +1,5 @@
 import Section from '@/lib/Section'
-import Store from '@/store/Store'
+import StoreUtil from '@/store/StoreUtil';
 
 export default class DateUtil {
   // 現地時間のyyyy-mm-dd形式の文字列を返す
@@ -113,7 +113,7 @@ export default class DateUtil {
    * 年月は1970年1月
    */
   public static getFirstSectionTime(): Date {
-    const sections: Section[] = Store.getters['section/sections']
+    const sections: Section[] = StoreUtil.getSectionList()
     if (sections.length > 0) {
       return sections[0].startTime
     } else {

--- a/tests/unit/util/DateUtil.spec.ts
+++ b/tests/unit/util/DateUtil.spec.ts
@@ -1,17 +1,10 @@
-import DateUtil from '@/util/DateUtil'
-jest.mock('vuex', () => {
-  getters: jest.fn(() => {
-    [{startTime: new Date(1970, 0, 1, 5, 0)}]
-  })
-})
-jest.mock('vue', () => {
-  use: jest.fn(() => {
-    //
-  })
-})
+jest.mock('@/store/StoreUtil', () => ({
+  // セクションの開始時間は朝5時にする
+  getSectionList: jest.fn(() => [{startTime: new Date(1970, 0, 1, 5, 0)}]),
+}))
 
-import Vuex from 'vuex'
-import Vue from 'vue'
+import StoreUtil from '@/store/StoreUtil'
+import DateUtil from '@/util/DateUtil'
 
 describe('DateUtil.ts', () => {
   describe('getDateObjectByDate', () => {
@@ -28,28 +21,6 @@ describe('DateUtil.ts', () => {
     })
 
     describe('Store定義ありパターン', () => {
-      // let sectionSpy
-      beforeEach(() => {
-        // store = require('@/store/Store')
-        // store.get.mockReturnValueOnce('[{startTime: new Date(1970, 0, 1, 5, 0)}]')
-
-        // これももだめ
-        // store = require('@/store/Store')
-        // sectionSpy = jest.spyOn(store, 'getters')
-        // sectionSpy.mockImplementationOnce(() => new Date(1970, 0, 1, 5, 0))
-
-        // これだとどこでもセットしてない
-        // store = new Vuex.Store({
-        //   modules: {
-        //     section: {
-        //       state: {
-        //         // 朝五時が最初のセクション
-        //         sections: [{startTime: new Date(1970, 0, 1, 5, 0)}],
-        //       },
-        //     },
-        //   },
-        // })
-      })
 
       it('一日の開始セクションより後なので単純にがっちゃんこされるはず', () => {
         // 2019-2-1 0:00


### PR DESCRIPTION
今までDateUtil.ts内からStoreを直接読み出していたところかうまくモック化できなかったが、ストアへのアクセス部分を別のテスト対象外クラスに切り出して、そのクラスをモック化して対応できた。

頑張れば直接Vuexのストアをモック化できるかもしれないが、一旦これで対応する。

またjestがbable6では動かなかったので7 bridgeに変更。
