### PR TITLE
CSSクラス名がかぶりで意図しない動作になるのでscoped指定を追加

### DIFF
--- a/src/components/EstimateList.vue
+++ b/src/components/EstimateList.vue
@@ -187,5 +187,5 @@ export default class EstimateList extends Vue {
 }
 </script>
 
-<style>
+<style scoped>
 </style>

--- a/src/components/Footer.vue
+++ b/src/components/Footer.vue
@@ -16,6 +16,10 @@
   </v-footer>
 </template>
 
+<style scoped>
+
+</style>
+
 <script lang="ts">
 import { Component, Vue } from 'vue-property-decorator'
 import firebase from 'firebase'

--- a/src/components/Header.vue
+++ b/src/components/Header.vue
@@ -33,7 +33,7 @@
   </v-toolbar>
 </template>
 
-<style>
+<style scoped>
 .menu {
   z-index: 200;
 }

--- a/src/components/NewTask.vue
+++ b/src/components/NewTask.vue
@@ -97,7 +97,7 @@ export default class NewTask extends Vue {
 }
 </script>
 
-<style>
+<style scoped>
 </style>
 
 

--- a/src/components/Note.vue
+++ b/src/components/Note.vue
@@ -40,7 +40,7 @@
   </v-layout>
 </template>
 
-<style>
+<style scoped>
 .wrap {
   white-space: pre-line;
 }</style>

--- a/src/components/RepeatEdit.vue
+++ b/src/components/RepeatEdit.vue
@@ -301,7 +301,7 @@ export default class RepeatEdit extends Vue {
 }
 </script>
 
-<style>
+<style scoped>
 </style>
 
 

--- a/src/components/SectionRow.vue
+++ b/src/components/SectionRow.vue
@@ -94,7 +94,7 @@ export default class SectionRow extends Vue {
 }
 </script>
 
-<style>
+<style scoped>
 </style>
 
 

--- a/src/components/TaskEdit.vue
+++ b/src/components/TaskEdit.vue
@@ -283,7 +283,7 @@ export default class TaskEdit extends Vue {
 }
 </script>
 
-<style>
+<style scoped>
 </style>
 
 

--- a/src/components/TaskNote.vue
+++ b/src/components/TaskNote.vue
@@ -8,7 +8,7 @@
   ></Note>
 </template>
 
-<style>
+<style scoped>
 .wrap {
   white-space: pre-line;
 }</style>

--- a/src/components/TaskRow.vue
+++ b/src/components/TaskRow.vue
@@ -129,7 +129,7 @@
   </v-container>
 </template>
 
-<style>
+<style scoped>
 .done {
   text-decoration: line-through;
 }

--- a/src/views/SectionList.vue
+++ b/src/views/SectionList.vue
@@ -31,7 +31,7 @@
   </div>
 </template>
 
-<style>
+<style scoped>
 .fixed-header {
   position: fixed;
   width: 100%;

--- a/src/views/TaskListMain.vue
+++ b/src/views/TaskListMain.vue
@@ -1,6 +1,6 @@
 <template>
   <div id="main">
-    <div class="tasklist-fixed-header">
+    <div class="fixed-header">
       <Header
         v-on:clickjumpToNextTaskButtomEvent="jumpToNextTask()"
       ></Header>
@@ -93,16 +93,16 @@
   </div>
 </template>
 
-<style>
-.tasklist-fixed-header {
+<style scoped>
+.fixed-header {
   position: fixed;
   width: 100%;
   z-index: 100;
 }
-.tasklist-listSp {
+.listSp {
   padding-top: 210px;
 }
-.tasklist-listPc {
+.listPc {
   padding-top: 150px;
 }
 </style>
@@ -191,12 +191,12 @@ export default class TaskListMain extends Vue {
   get listClass(): {} {
     // 画面サイズによってツールバーとのマージンを変更
     switch (this.$vuetify.breakpoint.name) {
-        case 'xs': return {class: 'tasklist-listSp'}
-        case 'sm': return {class: 'tasklist-listSp'}
-        case 'md': return {class: 'tasklist-listPc'}
-        case 'lg': return {class: 'tasklist-listPc'}
-        case 'xl': return {class: 'tasklist-listPc'}
-        default  : return {class: 'tasklist-listPc'}
+        case 'xs': return {class: 'listSp'}
+        case 'sm': return {class: 'listSp'}
+        case 'md': return {class: 'listPc'}
+        case 'lg': return {class: 'listPc'}
+        case 'xl': return {class: 'listPc'}
+        default  : return {class: 'listPc'}
     }
   }
 


### PR DESCRIPTION
過去にcssのクラス名がコンポーネント同士でかぶって正しく動作しなかった件で、クラス名を重複しないように修正したが、scoped指定することで自動的に回避されることを知ったので適用。
