### PR TITLE
Smallサイズ(sm)の画面の場合に現在タスクへのジャンプがズレる件の修正

### DIFF
--- a/src/views/TaskListMain.vue
+++ b/src/views/TaskListMain.vue
@@ -495,6 +495,9 @@ export default class TaskListMain extends Vue {
       case 'xs':
         offsetValue = 320
         break
+      case 'sm':
+        offsetValue = 270
+        break
       default  :
         offsetValue = 185
     }


### PR DESCRIPTION
HDサイズのディスプレイの半分にしたときぐらいに問題が起きる(960px以下)。
レスポンシブで日付と見積が縦に並ぶ状態になるとズレる。
